### PR TITLE
fix: published fields not propagated to draft record

### DIFF
--- a/build-tests/thesis.yaml
+++ b/build-tests/thesis.yaml
@@ -10,8 +10,6 @@ record:
     qualified: thesis
   permissions:
     presets: [ 'everyone' ]
-#  package: thesis
-#  schema-server: 'local://'
   use:
   - invenio
   draft:
@@ -26,13 +24,3 @@ record:
 profiles:
   - record
   - draft
-#files:
-#  use:
-#  - invenio_files
-#  properties:
-#    metadata:
-#      properties:
-#        title:
-#          type: fulltext
-#  package: thesis
-#  schema-server: 'local://'

--- a/oarepo_model_builder_drafts/datatypes/components/draft_model/record.py
+++ b/oarepo_model_builder_drafts/datatypes/components/draft_model/record.py
@@ -1,7 +1,7 @@
-from oarepo_model_builder.datatypes import ModelDataType
+from oarepo_model_builder.datatypes import DataType, ModelDataType
 from oarepo_model_builder.datatypes.components import RecordModelComponent
 from oarepo_model_builder.datatypes.components.model.utils import set_default
-from oarepo_model_builder.datatypes import DataType
+
 
 class DraftRecordModelComponent(RecordModelComponent):
     eligible_datatypes = [ModelDataType]
@@ -25,7 +25,25 @@ class DraftRecordModelComponent(RecordModelComponent):
             extra_code = datatype.model.get("extra-code", "")
             record.setdefault("extra-code", extra_code)
             is_record_preset = record.get("class", None)
-            record.setdefault("fields", published_record_datatype.definition["record"]["fields"]) #if fields defined on draft, still propagate the record ones?
+
+            # get draft record fields
+            draft_record_fields = record.setdefault("fields", {})
+
+            # for each published field, add it to the draft record fields if it is not already there
+            published_record_fields = published_record_datatype.definition["record"][
+                "fields"
+            ]
+            for (
+                published_field_name,
+                published_field,
+            ) in published_record_fields.items():
+                if published_field_name not in draft_record_fields:
+                    draft_record_fields[published_field_name] = published_field
+
+            # null value is used to remove the field from the draft record
+            # even if it is present in the published record
+            draft_record_fields = {k: v for k, v in draft_record_fields.items() if v}
+
             super().before_model_prepare(datatype, context=context, **kwargs)
             if not is_record_preset and record["class"][-6:] == "Record":
                 record["class"] = record["class"][:-6]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = oarepo-model-builder-drafts
-version = 4.0.34
+version = 4.0.35
 description =
 authors = Ronald Krist <krist@cesnet.cz>
 readme = README.md


### PR DESCRIPTION
As state field is already present in draft record's fields, the published fields were not copied over. This fix copies all fields from published if they are not already present on draft.

Fields evaluating to False/None are subsequently removed.